### PR TITLE
Fix handling of shadowing for exempt calls.

### DIFF
--- a/lib/bpl/transformation/shadowing.rb
+++ b/lib/bpl/transformation/shadowing.rb
@@ -129,7 +129,7 @@ module Bpl
             when CallStatement
               if exempt?(stmt.procedure.name)
                 stmt.assignments.each do |x|
-                  stmt.insert_after(bpl("#{x} := #{shadow(x)};"))
+                  stmt.insert_after(bpl("#{shadow(x)} := #{x};"))
                 end
               else
                 (stmt.arguments + stmt.assignments).each do |arg|


### PR DESCRIPTION
Was turning 'x = call (arg)' into 'x = call (arg); x := x.shadow'.

This is just a quick fix. Per function handling may be needed in the near future.