### PR TITLE
Do not generate shadow procedures for `corral_atomic_*`

### DIFF
--- a/lib/bpl/passes/security/shadowing.rb
+++ b/lib/bpl/passes/security/shadowing.rb
@@ -131,6 +131,7 @@ module Bpl
       '\$alloc',
       '\$free',
       'boogie_si_',
+      'corral_atomic_',
       '__VERIFIER_',
       '__SMACK_(?!static_init)',
       '__memcpy_chk',


### PR DESCRIPTION
SMACK recently adds calls to `corral_atomic_*` to allocators, which do not have definitions. BAM adds calls to their shadow counterparts but not declare the shadow ones, causing parsing errors. This PR fixes this issue by adding such functions to the exemption list.